### PR TITLE
完善项目文档并梳理 docs 结构

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,330 +1,84 @@
 # wecom-cli
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Rust](https://img.shields.io/badge/rust-%3E%3D1.75-orange.svg)](https://www.rust-lang.org/)
 
 > 💬 扫码加入企业微信交流群：
 >
 > <img src="https://wwcdn.weixin.qq.com/node/wework/images/202603241759.3fb01c32cc.png" alt="扫码入群交流" width="200" />
 
-企业微信命令行工具 — 让人类和 AI Agent 都能在终端中操作企业微信。覆盖通讯录、待办、会议、消息、日程、文档、智能表格等核心业务域，提供 7 大品类及 12 个 AI Agent [Skills](https://github.com/WecomTeam/wecom-cli/tree/main/skills)。
+企业微信官方命令行工具，让人类和 AI Agent 都能在终端里操作企业微信。仓库同时提供 CLI、跨平台 npm 二进制分发，以及 12 个开箱即用的 Agent Skills。
 
-[安装](#安装与快速开始) · [AI Agent Skills](#agent-skills) · [命令](#命令参考) · [品类一览](#品类与能力一览)
+[安装与快速开始](docs/getting-started.md) · [CLI 使用约定](docs/cli-reference.md) · [Skills 导航](docs/skills.md) · [开发说明](docs/development.md)
 
-## 为什么选 wecom-cli？
+## 为什么使用 wecom-cli
 
-- **为 AI Agent 所设计** — 开箱即用的 [Skills](https://github.com/WecomTeam/wecom-cli/tree/main/skills)， 适配主流 AI 工具，Agent 可直接操作企业微信，无需额外适配
-- **覆盖用户核心需求** — 7 大业务品类、12 个 AI Agent [Skills](https://github.com/WecomTeam/wecom-cli/tree/main/skills)，覆盖通讯录、待办、会议、消息、日程、文档与智能表格
-- **快速上手** — `init` 配置凭证，直接调用品类工具，从安装到第一次 API 调用只需两步
+- 面向 Agent：仓库内置 12 个 Skills，可直接接入支持 Skill 机制的 AI 工具。
+- 覆盖核心业务：通讯录、待办、会议、消息、日程、文档、智能表格都可通过统一 CLI 访问。
+- 安装简单：通过 npm 安装主包后，即可在当前平台获得对应的本地二进制。
 
-## 功能
+## 能力概览
 
-| 类别         | 能力                                                                          |
-| ------------ | ----------------------------------------------------------------------------- |
-| 👤 通讯录   | 获取可见范围成员列表、按姓名/别名搜索                                        |
-| ✅ 待办     | 创建、查询列表、查询详情、更新、删除待办，变更用户处理状态                    |
-| 🎥 会议     | 创建预约会议、取消会议、更新受邀成员、查询会议列表、获取会议详情              |
-| 💬 消息     | 会话列表查询、消息记录拉取（文本/图片/文件/语音/视频）、多媒体下载、发送文本  |
-| 📅 日程     | 日程 CRUD、参与人管理、多成员闲忙查询                                         |
-| 📄 文档     | 文档创建/读取/编辑                                                            |
-| 📊 智能表格   | 智能表格创建、子表与字段管理、表格记录增删改查                                  |
+| 领域 | 能力 |
+| --- | --- |
+| `contact` | 获取可见范围成员列表，按姓名或别名匹配 |
+| `todo` | 查询、创建、更新、删除待办，变更用户处理状态 |
+| `meeting` | 创建预约会议，取消会议，查询会议列表和详情 |
+| `msg` | 查询会话、拉取消息、下载媒体、发送文本消息 |
+| `schedule` | 日程增删改查、参与人管理、多成员闲忙查询 |
+| `doc` | 文档创建、导出、编辑，以及智能表格结构与数据管理 |
 
-## 安装与快速开始
+## 三分钟上手
 
-### 环境要求
+运行前提：
 
-- Node.js（`npm`/`npx`）
+- Node.js `>= 18`
 - 企业微信机器人的 Bot ID 和 Secret
 
-### 安装
+安装：
 
 ```bash
-# 安装 CLI
 npm install -g @wecom/cli
-
-# 安装 CLI SKILL（必需）
 npx skills add WeComTeam/wecom-cli -y -g
 ```
 
-### 快速开始
-
-```bash
-# 1. 配置企业微信机器人凭证（交互式，仅需一次）
-wecom-cli init
-
-# 2. 调用工具
-wecom-cli contact get_userlist '{}'
-```
-
-## Agent Skills
-
-| Skill | 品类 | 说明 |
-| ----- | ---- | ---- |
-| `wecomcli-lookup-contact` | contact | 通讯录成员查询，按姓名/别名搜索 |
-| `wecomcli-get-todo-list` | todo | 待办列表查询，按时间过滤和分页 |
-| `wecomcli-get-todo-detail` | todo | 待办详情批量查询 |
-| `wecomcli-edit-todo` | todo | 待办创建、更新、删除、状态变更 |
-| `wecomcli-create-meeting` | meeting | 创建预约会议 |
-| `wecomcli-edit-meeting` | meeting | 取消会议、更新受邀成员 |
-| `wecomcli-get-meeting` | meeting | 查询会议列表和详情 |
-| `wecomcli-get-msg` | msg | 会话列表、消息记录、媒体下载、文本发送 |
-| `wecomcli-manage-schedule` | schedule | 日程 CRUD、参与人管理、闲忙查询 |
-| `wecomcli-manage-doc` | doc | 文档创建/读取/编辑 |
-| `wecomcli-manage-smartsheet-schema` | smartsheet | 智能表格子表与字段管理 |
-| `wecomcli-manage-smartsheet-data` | smartsheet | 智能表格记录增删改查 |
-
-## 命令参考
-
-### `--help`
-
-列出所有支持的命令和品类。
-
-```bash
-wecom-cli --help
-```
-
-输出示例：
-
-```
-Usage: wecom-cli <COMMAND>
-
-Commands:
-  init      Documentation for init
-  contact   通讯录 — 成员查询和搜索
-  doc       文档 — 文档/智能表格创建和管理
-  meeting   会议 — 创建/管理/查询视频会议
-  msg       消息 — 聊天列表、发送/接收消息、媒体下载
-  schedule  日程 — 日程增删改查和可用性查询
-  todo      待办事项 — 创建/查询/编辑待办项
-
-Options:
-  -h, --help     Print help
-  -V, --version  Print version
-```
-
-### `init`
-
-交互式配置企业微信机器人凭证，加密存储到本地。仅需执行一次。
+初始化：
 
 ```bash
 wecom-cli init
 ```
 
-| 参数       | 必填 | 说明           |
-| ---------- | ---- | -------------- |
-| `--bot-id` | 可选 | 企业微信机器人 Bot ID  |
-
-
-凭证存储位置：`~/.config/wecom/bot.enc`
-
-### 品类调用
-
-每个品类作为独立子命令使用。不传方法名时列出该品类下所有可用工具，传方法名时调用指定工具。
+第一次调用：
 
 ```bash
-# 列出品类下的所有工具
-wecom-cli <category>
-
-# 调用品类下的指定工具
-wecom-cli <category> <method> [json_args]
-```
-
-示例：
-
-```bash
-# 列出通讯录品类下的工具
-wecom-cli contact
-
-# 列出待办品类下的工具
-wecom-cli todo
-
-# 调用工具（传 JSON 参数）
-wecom-cli contact get_userlist '{}'
-
-# 调用工具（无参数）
-wecom-cli contact get_userlist
-```
-
-## 品类与能力一览
-
-### contact — 通讯录
-
-| 工具 | 说明 |
-|------|------|
-| `get_userlist` | 获取当前用户可见范围内的通讯录成员（userid、姓名、别名） |
-
-```bash
-# 获取全量通讯录成员
 wecom-cli contact get_userlist '{}'
 ```
 
-### todo — 待办
+使用提示：
 
-| 工具 | 说明 |
-|------|------|
-| `get_todo_list` | 查询待办列表，支持按时间过滤和分页 |
-| `get_todo_detail` | 根据待办 ID 批量查询完整详情 |
-| `create_todo` | 创建待办，可指定内容、分派人、提醒时间 |
-| `update_todo` | 更新待办内容、状态、分派人或提醒时间 |
-| `delete_todo` | 删除待办（不可撤销） |
-| `change_todo_user_status` | 变更当前用户在待办中的状态 |
+- `wecom-cli --help` 可以直接查看顶层帮助。
+- `wecom-cli <category>` 和 `wecom-cli <category> --help` 需要先完成 `init`，因为会去拉取远程 MCP 工具定义。
+- 对于无业务参数的工具，也建议显式传 `'{}'`；只写到 `<method>` 时，当前行为是显示 schema/help，而不是执行调用。
 
-```bash
-# 查询待办列表
-wecom-cli todo get_todo_list '{}'
+## 文档地图
 
-# 创建待办
-wecom-cli todo create_todo '{"content": "完成Q2规划文档", "remind_time": "2026-06-01 09:00:00"}'
+- [`docs/README.md`](docs/README.md)：文档入口和维护边界
+- [`docs/getting-started.md`](docs/getting-started.md)：安装、初始化、首个调用
+- [`docs/cli-reference.md`](docs/cli-reference.md)：命令格式、帮助行为、运行时路径、环境变量
+- [`docs/skills.md`](docs/skills.md)：12 个 Skills 的索引和入口
+- [`docs/development.md`](docs/development.md)：源码结构、本地调试和打包边界
 
-# 批量查询待办详情
-wecom-cli todo get_todo_detail '{"todo_id_list": ["TODO_ID_1", "TODO_ID_2"]}'
+## Skills 一览
 
-# 标记待办完成
-wecom-cli todo update_todo '{"todo_id": "TODO_ID", "todo_status": 0}'
+| 领域 | Skills |
+| --- | --- |
+| `contact` | `wecomcli-lookup-contact` |
+| `todo` | `wecomcli-get-todo-list`, `wecomcli-get-todo-detail`, `wecomcli-edit-todo` |
+| `meeting` | `wecomcli-create-meeting`, `wecomcli-edit-meeting`, `wecomcli-get-meeting` |
+| `msg` | `wecomcli-get-msg` |
+| `schedule` | `wecomcli-manage-schedule` |
+| `doc` | `wecomcli-manage-doc`, `wecomcli-manage-smartsheet-schema`, `wecomcli-manage-smartsheet-data` |
 
-# 删除待办
-wecom-cli todo delete_todo '{"todo_id": "TODO_ID"}'
-```
-
-### meeting — 会议
-
-| 工具 | 说明 |
-|------|------|
-| `create_meeting` | 创建预约会议，支持设置参数、邀请参与人、安全设置 |
-| `cancel_meeting` | 取消指定的预约会议 |
-| `set_invite_meeting_members` | 更新会议受邀成员（全量覆盖） |
-| `list_user_meetings` | 查询用户在时间范围内的会议列表（当日前后 30 天） |
-| `get_meeting_info` | 获取会议完整详情 |
-
-```bash
-# 查询本周会议
-wecom-cli meeting list_user_meetings '{"begin_datetime": "2026-03-23 00:00", "end_datetime": "2026-03-29 23:59", "limit": 100}'
-
-# 创建会议
-wecom-cli meeting create_meeting '{"title": "技术方案评审", "meeting_start_datetime": "2026-03-30 15:00", "meeting_duration": 3600, "invitees": {"userid": ["zhangsan", "lisi"]}}'
-
-# 获取会议详情
-wecom-cli meeting get_meeting_info '{"meetingid": "MEETING_ID"}'
-
-# 取消会议
-wecom-cli meeting cancel_meeting '{"meetingid": "MEETING_ID"}'
-```
-
-### msg — 消息
-
-| 工具 | 说明 |
-|------|------|
-| `get_msg_chat_list` | 按时间范围查询有消息的会话列表 |
-| `get_message` | 拉取会话消息记录（支持文本/图片/文件/语音/视频） |
-| `get_msg_media` | 下载消息中的多媒体文件到本地 |
-| `send_message` | 向单聊或群聊发送文本消息 |
-
-```bash
-# 获取最近一周会话列表
-wecom-cli msg get_msg_chat_list '{"begin_time": "2026-03-22 00:00:00", "end_time": "2026-03-29 23:59:59"}'
-
-# 拉取聊天记录
-wecom-cli msg get_message '{"chat_type": 1, "chatid": "zhangsan", "begin_time": "2026-03-29 09:00:00", "end_time": "2026-03-29 18:00:00"}'
-
-# 发送文本消息
-wecom-cli msg send_message '{"chat_type": 1, "chatid": "zhangsan", "msgtype": "text", "text": {"content": "hello"}}'
-
-# 下载多媒体文件
-wecom-cli msg get_msg_media '{"media_id": "MEDIA_ID"}'
-```
-
-### schedule — 日程
-
-| 工具 | 说明 |
-|------|------|
-| `get_schedule_list_by_range` | 查询时间范围内的日程 ID 列表（当日前后 30 天） |
-| `get_schedule_detail` | 批量获取日程详情（1~50 个） |
-| `create_schedule` | 创建日程，支持设置提醒、参与人 |
-| `update_schedule` | 修改日程（只传需修改的字段） |
-| `cancel_schedule` | 取消日程 |
-| `add_schedule_attendees` | 添加日程参与人 |
-| `del_schedule_attendees` | 移除日程参与人 |
-| `check_availability` | 查询多成员闲忙状态（1~10 人） |
-
-```bash
-# 查询今天的日程
-wecom-cli schedule get_schedule_list_by_range '{"start_time": "2026-03-29 00:00:00", "end_time": "2026-03-29 23:59:59"}'
-
-# 获取日程详情
-wecom-cli schedule get_schedule_detail '{"schedule_id_list": ["SCHEDULE_ID"]}'
-
-# 创建日程
-wecom-cli schedule create_schedule '{"schedule": {"start_time": "2026-03-30 14:00:00", "end_time": "2026-03-30 15:00:00", "summary": "需求评审", "attendees": [{"userid": "zhangsan"}], "reminders": {"is_remind": 1, "remind_before_event_secs": 900, "timezone": 8}}}'
-
-# 查询闲忙
-wecom-cli schedule check_availability '{"check_user_list": ["zhangsan", "lisi"], "start_time": "2026-03-30 09:00:00", "end_time": "2026-03-30 18:00:00"}'
-```
-
-### doc — 文档
-
-| 工具 | 说明 |
-|------|------|
-| `create_doc` | 创建文档（doc_type=3） |
-| `get_doc_content` | 获取文档内容（Markdown 格式，异步轮询） |
-| `edit_doc_content` | 用 Markdown 覆写文档正文 |
-
-```bash
-# 创建文档
-wecom-cli doc create_doc '{"doc_type": 3, "doc_name": "项目周报"}'
-
-# 读取文档内容（首次调用）
-wecom-cli doc get_doc_content '{"docid": "DOC_ID", "type": 2}'
-
-# 读取文档内容（轮询，携带 task_id）
-wecom-cli doc get_doc_content '{"docid": "DOC_ID", "type": 2, "task_id": "TASK_ID"}'
-
-# 编辑文档
-wecom-cli doc edit_doc_content '{"docid": "DOC_ID", "content": "# 标题\n\n正文内容", "content_type": 1}'
-```
-
-### doc — 智能表格
-
-| 工具 | 说明 |
-|------|------|
-| `create_doc` | 创建智能表格（通过 doc create_doc，doc_type=10） |
-| `smartsheet_get_sheet` | 查询智能表格的所有子表 |
-| `smartsheet_add_sheet` | 添加子表 |
-| `smartsheet_update_sheet` | 修改子表标题 |
-| `smartsheet_delete_sheet` | 删除子表（不可逆） |
-| `smartsheet_get_fields` | 查询子表的字段/列信息 |
-| `smartsheet_add_fields` | 添加字段/列 |
-| `smartsheet_update_fields` | 更新字段标题 |
-| `smartsheet_delete_fields` | 删除字段/列（不可逆） |
-| `smartsheet_get_records` | 查询子表全部记录 |
-| `smartsheet_add_records` | 添加记录 |
-| `smartsheet_update_records` | 更新记录 |
-| `smartsheet_delete_records` | 删除记录（不可逆） |
-
-```bash
-# 创建智能表格
-wecom-cli doc create_doc '{"doc_type": 10, "doc_name": "任务跟踪表"}'
-
-# 查询智能表格子表
-wecom-cli doc smartsheet_get_sheet '{"docid": "DOC_ID"}'
-
-# 查询子表字段信息
-wecom-cli doc smartsheet_get_fields '{"docid": "DOC_ID", "sheet_id": "SHEET_ID"}'
-
-# 添加子表字段
-wecom-cli doc smartsheet_add_fields '{"docid": "DOC_ID", "sheet_id": "SHEET_ID", "fields": [{"field_title": "状态", "field_type": "FIELD_TYPE_SINGLE_SELECT"}]}'
-
-# 查询子表记录
-wecom-cli doc smartsheet_get_records '{"docid": "DOC_ID", "sheet_id": "SHEET_ID"}'
-
-# 添加记录
-wecom-cli doc smartsheet_add_records '{"docid": "DOC_ID", "sheet_id": "SHEET_ID", "records": [{"values": {"标题": [{"type": "text", "text": "新任务"}]}}]}'
-
-# 更新记录
-wecom-cli doc smartsheet_update_records '{"docid": "DOC_ID", "sheet_id": "SHEET_ID", "key_type":"CELL_VALUE_KEY_TYPE_FIELD_TITLE", "records": [{"record_id": "RECORD_ID", "values": {"标题": [{"type": "text", "text": "已更新"}]}}]}'
-
-# 删除记录
-wecom-cli doc smartsheet_delete_records '{"docid": "DOC_ID", "sheet_id": "SHEET_ID", "record_ids": ["RECORD_ID"]}'
-```
+更具体的工作流和参数示例请直接查看 [`docs/skills.md`](docs/skills.md) 中对应的 Skill 链接。
 
 ## 许可证
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,28 @@
+# 文档中心
+
+本目录是 `wecom-cli` 的长期维护文档集，用来承载安装、使用约定、Skills 导航和开发说明。根 `README.md` 保持为项目首页，不再承担所有细节参考。
+
+## 从这里开始
+
+- 新用户安装和第一次调用：[`docs/getting-started.md`](getting-started.md)
+- 查 CLI 行为、运行时路径和环境变量：[`docs/cli-reference.md`](cli-reference.md)
+- 查 12 个内置 Skills 的分工和入口：[`docs/skills.md`](skills.md)
+- 本地开发、调试和仓库结构：[`docs/development.md`](development.md)
+
+## Source Of Truth
+
+| 位置 | 负责内容 |
+| --- | --- |
+| `README.md` | 项目介绍、价值主张、最短上手路径 |
+| `docs/getting-started.md` | 安装、初始化、首个成功调用 |
+| `docs/cli-reference.md` | 已验证的 CLI 约定、帮助行为、运行时路径、环境变量 |
+| `docs/skills.md` | Skills 索引、分类和跳转入口 |
+| `skills/*/SKILL.md` | 单个 Skill 的工作流、参数示例、补充参考资料 |
+| `packages/*/README.md` | 平台二进制包的最小安装说明 |
+
+## 维护约定
+
+- 优先把持续维护的说明写进 `docs/`，避免再次把根 `README.md` 写成长篇参考手册。
+- 同一主题只保留一个主入口；其他页面通过链接复用，不复制大段相同内容。
+- 写工具示例时，无入参工具也显式传 `'{}'`，避免和“显示 schema/help”行为混淆。
+- 若命令、路径、环境变量无法从仓库确认，就不要写入文档。

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,98 @@
+# CLI 使用约定
+
+这页只记录已经从仓库实现中核对过的 CLI 事实，避免把营销文案、Skill 工作流和运行时行为混在一起。
+
+## 命令总览
+
+顶层命令：
+
+```bash
+wecom-cli --help
+```
+
+当前内置命令与品类：
+
+| 命令 | 说明 |
+| --- | --- |
+| `init` | 初始化机器人凭证，或刷新 MCP 配置 |
+| `contact` | 通讯录成员查询和搜索 |
+| `doc` | 文档和智能表格创建/管理 |
+| `meeting` | 视频会议创建、管理和查询 |
+| `msg` | 聊天列表、消息收发和媒体下载 |
+| `schedule` | 日程增删改查和闲忙查询 |
+| `todo` | 待办创建、查询和编辑 |
+
+## 调用格式
+
+通用格式：
+
+```bash
+wecom-cli <category> <method> '<json_args>'
+```
+
+例如：
+
+```bash
+wecom-cli contact get_userlist '{}'
+wecom-cli meeting get_meeting_info '{"meetingid": "MEETING_ID"}'
+wecom-cli doc create_doc '{"doc_type": 3, "doc_name": "项目周报"}'
+```
+
+## 已验证行为
+
+| 场景 | 行为 |
+| --- | --- |
+| `wecom-cli --help` | 直接输出本地顶层帮助，不依赖初始化 |
+| `wecom-cli init --help` | 直接输出 `init` 参数说明 |
+| `wecom-cli <category>` | 远程拉取该品类的工具列表；如果尚未 `init`，会失败 |
+| `wecom-cli <category> --help` | 与上面一样，会拉取远程工具列表，因此同样依赖已完成初始化 |
+| `wecom-cli <category> <method>` | 输出该工具的 schema/help，不会真正调用 |
+| `wecom-cli <category> <method> '<json_args>'` | 真正执行 JSON-RPC 工具调用 |
+| `wecom-cli msg get_msg_media ...` | 会把媒体文件下载到本地临时目录，并在结果里返回 `local_path` |
+
+补充说明：
+
+- 分类工具列表和工具 schema 都来自 MCP 接口，因此“看帮助”本身也依赖凭证与网络。
+- 普通工具调用默认超时为 30 秒；`get_msg_media` 使用 120 秒超时。
+
+## 初始化与帮助建议
+
+推荐顺序：
+
+```bash
+wecom-cli --help
+wecom-cli init
+wecom-cli contact --help
+wecom-cli contact get_userlist '{}'
+```
+
+如果你只执行下面这条：
+
+```bash
+wecom-cli contact get_userlist
+```
+
+当前行为是显示 `get_userlist` 的输入 schema，而不是实际返回通讯录数据。
+
+## 运行时路径
+
+| 项目 | 默认位置 | 备注 |
+| --- | --- | --- |
+| 配置目录 | `~/.config/wecom` | 可由 `WECOM_CLI_CONFIG_DIR` 覆盖 |
+| 机器人凭证 | `<config_dir>/bot.enc` | 初始化时创建 |
+| MCP 配置缓存 | `<config_dir>/mcp_config.enc` | 初始化或刷新后更新 |
+| 媒体临时目录 | `<system_tmp>/wecom/media` | 可由 `WECOM_CLI_TMP_DIR` 覆盖根目录 |
+
+## 环境变量
+
+| 变量 | 作用 |
+| --- | --- |
+| `WECOM_CLI_CONFIG_DIR` | 覆盖默认配置目录 |
+| `WECOM_CLI_TMP_DIR` | 覆盖媒体临时目录的根目录 |
+| `WECOM_CLI_LOG_LEVEL` | 打开 stderr 日志并设置过滤级别 |
+| `WECOM_CLI_LOG_FILE` | 打开 JSON 日志输出，按天写入 `ww.log` |
+| `WECOM_CLI_MCP_CONFIG_ENDPOINT` | 覆盖默认 MCP 配置接口地址 |
+
+## 详细业务能力
+
+具体参数结构、工作流示例和补充参考不再复制到这页，统一从 [`docs/skills.md`](skills.md) 进入各个 Skill 的 `SKILL.md`。

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,44 @@
+# 开发说明
+
+这页面向仓库维护者和贡献者，记录源码结构、常用本地命令和打包边界。
+
+## 仓库结构
+
+| 路径 | 说明 |
+| --- | --- |
+| `src/` | Rust CLI 主实现，包括命令解析、认证、JSON-RPC、日志和媒体处理 |
+| `bin/wecom.js` | npm 入口脚本，负责定位并执行当前平台的二进制 |
+| `packages/*` | 各平台的 npm 二进制包 |
+| `skills/*` | Agent Skills 及其补充参考资料 |
+| `docs/` | 持续维护的使用与开发文档 |
+| `README.md` | 项目首页 |
+
+## 本地开发
+
+仓库的 Rust crate 使用 `edition = "2024"`，开发时建议使用较新的 stable Rust 工具链。
+
+常用命令：
+
+```bash
+cargo run -- --help
+cargo run -- init --help
+cargo test
+```
+
+如果你需要验证 npm 包装层：
+
+```bash
+pnpm install
+```
+
+说明：
+
+- 根包名为 `@wecom/cli`，实际可执行入口是 `bin/wecom.js`。
+- 平台二进制通过 `optionalDependencies` 分发，位于 `packages/*`。
+- `pnpm-workspace.yaml` 当前只管理 `packages/*` 工作区。
+
+## 文档维护建议
+
+- 根 `README.md` 只保留首页信息和文档导航。
+- 安装、CLI 行为和开发细节统一写入 `docs/`。
+- 单个 Skill 的复杂示例保留在对应 `skills/*/SKILL.md`，不要在多个地方复制一遍。

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,60 @@
+# 安装与快速开始
+
+这页覆盖从安装 `wecom-cli` 到第一次成功调用的最短路径。更完整的 CLI 行为说明见 [`docs/cli-reference.md`](cli-reference.md)。
+
+## 运行前提
+
+- Node.js `>= 18`。
+- 企业微信机器人的 Bot ID 和 Secret。
+- 受支持的平台为：
+
+| OS | CPU | 对应包 |
+| --- | --- | --- |
+| macOS | arm64 | `@wecom/cli-darwin-arm64` |
+| macOS | x64 | `@wecom/cli-darwin-x64` |
+| Linux | x64 | `@wecom/cli-linux-x64` |
+| Windows | x64 | `@wecom/cli-win32-x64` |
+
+## 安装 CLI 与 Skills
+
+```bash
+npm install -g @wecom/cli
+npx skills add WeComTeam/wecom-cli -y -g
+```
+
+说明：
+
+- `@wecom/cli` 主包通过可选依赖分发平台二进制，不需要单独安装平台包。
+- 如果安装后提示找不到二进制，先检查 npm 是否禁用了 optional dependencies。
+
+## 首次初始化
+
+```bash
+wecom-cli init
+```
+
+常用变体：
+
+```bash
+wecom-cli init --bot-id <BOT_ID>
+wecom-cli init --refresh
+```
+
+说明：
+
+- `init` 会交互式收集凭证、加密写入本地，并刷新 MCP 配置。
+- `--refresh` 只刷新 MCP 后台配置，不会重新录入 Secret。
+
+## 第一次调用
+
+```bash
+wecom-cli contact get_userlist '{}'
+```
+
+对于没有业务参数的工具，也建议显式传 `'{}'`。当前 CLI 在只写到 `<method>`、不传 `json_args` 时，会展示该工具的 schema/help，而不是直接发起调用。
+
+## 下一步
+
+- 想先看命令结构和帮助行为：[`docs/cli-reference.md`](cli-reference.md)
+- 想知道有哪些内置 Skill：[`docs/skills.md`](skills.md)
+- 想本地开发或调试：[`docs/development.md`](development.md)

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,28 @@
+# Skills 导航
+
+仓库当前内置 12 个 Agent Skills，位于 `skills/` 目录下。这里负责给出分类和入口；每个 Skill 的具体工作流、参数示例和补充参考仍以各自的 `SKILL.md` 为准。
+
+通用 CLI 行为以 [`docs/cli-reference.md`](cli-reference.md) 为准；如果某个 Skill 页面对“帮助行为”或“是否需要传 `'{}'`”没有展开说明，请优先遵循 CLI 参考页。
+
+## 按领域查看
+
+| Skill | 领域 | 用途 |
+| --- | --- | --- |
+| [`wecomcli-lookup-contact`](../skills/wecomcli-lookup-contact/SKILL.md) | `contact` | 获取可见成员列表，按姓名或别名匹配 |
+| [`wecomcli-get-todo-list`](../skills/wecomcli-get-todo-list/SKILL.md) | `todo` | 查询待办列表与分页信息 |
+| [`wecomcli-get-todo-detail`](../skills/wecomcli-get-todo-detail/SKILL.md) | `todo` | 批量获取待办完整详情 |
+| [`wecomcli-edit-todo`](../skills/wecomcli-edit-todo/SKILL.md) | `todo` | 创建、更新、删除待办和变更状态 |
+| [`wecomcli-create-meeting`](../skills/wecomcli-create-meeting/SKILL.md) | `meeting` | 创建预约会议 |
+| [`wecomcli-edit-meeting`](../skills/wecomcli-edit-meeting/SKILL.md) | `meeting` | 取消会议和更新受邀成员 |
+| [`wecomcli-get-meeting`](../skills/wecomcli-get-meeting/SKILL.md) | `meeting` | 查询会议列表和会议详情 |
+| [`wecomcli-get-msg`](../skills/wecomcli-get-msg/SKILL.md) | `msg` | 查看聊天、拉取消息、下载媒体、发送文本 |
+| [`wecomcli-manage-schedule`](../skills/wecomcli-manage-schedule/SKILL.md) | `schedule` | 管理日程、参与人和闲忙 |
+| [`wecomcli-manage-doc`](../skills/wecomcli-manage-doc/SKILL.md) | `doc` | 创建、导出和编辑企业微信文档 |
+| [`wecomcli-manage-smartsheet-schema`](../skills/wecomcli-manage-smartsheet-schema/SKILL.md) | `doc` | 管理智能表格的子表与字段结构 |
+| [`wecomcli-manage-smartsheet-data`](../skills/wecomcli-manage-smartsheet-data/SKILL.md) | `doc` | 读取、写入、更新和删除智能表格记录 |
+
+## 维护边界
+
+- 需要跨 Skill 的通用规则时，优先写到 `docs/cli-reference.md`。
+- 需要单个业务域的输入输出细节时，写到对应 Skill 目录。
+- 需要补充接口示例、字段枚举或格式说明时，优先放到该 Skill 的 `references/` 子目录。

--- a/skills/wecomcli-manage-schedule/SKILL.md
+++ b/skills/wecomcli-manage-schedule/SKILL.md
@@ -77,10 +77,10 @@ wecom-cli schedule add_schedule_attendees '{"schedule_id": "SCHEDULE_ID", "atten
 wecom-cli schedule del_schedule_attendees '{"schedule_id": "SCHEDULE_ID", "attendees": [{"userid": "USER_ID"}]}'
 ```
 
-### check_availablity — 查询闲忙
+### check_availability — 查询闲忙
 
 ```bash
-wecom-cli schedule check_availablity '{"check_user_list": ["USER_ID_1", "USER_ID_2"], "start_time": "YYYY-MM-DD HH:MM:SS", "end_time": "YYYY-MM-DD HH:MM:SS"}'
+wecom-cli schedule check_availability '{"check_user_list": ["USER_ID_1", "USER_ID_2"], "start_time": "YYYY-MM-DD HH:MM:SS", "end_time": "YYYY-MM-DD HH:MM:SS"}'
 ```
 
 支持 1~10 个用户，返回各用户的忙碌时段列表。参见 [API 详情](references/api-check-availability.md)。
@@ -171,6 +171,6 @@ wecom-cli schedule check_availablity '{"check_user_list": ["USER_ID_1", "USER_ID
 
 **流程：**
 1. 通过 **wecomcli-lookup-contact** 获取相关人员 userid
-2. 调用 `check_availablity` 查询指定时间范围内各用户的忙碌时段
+2. 调用 `check_availability` 查询指定时间范围内各用户的忙碌时段
 3. 分析所有用户的忙碌时段，计算出共同空闲时段并推荐给用户
 4. 用户确认时段后，调用 `create_schedule` 创建会议并自动添加参与人

--- a/skills/wecomcli-manage-schedule/references/api-check-availability.md
+++ b/skills/wecomcli-manage-schedule/references/api-check-availability.md
@@ -1,4 +1,4 @@
-# check_availablity API
+# check_availability API
 
 查询指定用户在某时间范围内的忙碌时段。
 
@@ -13,7 +13,7 @@
 ## 请求示例
 
 ```bash
-wecom-cli schedule check_availablity '{"check_user_list": ["USER_ID_1", "USER_ID_2"], "start_time": "YYYY-MM-DD HH:MM:SS", "end_time": "YYYY-MM-DD HH:MM:SS"}'
+wecom-cli schedule check_availability '{"check_user_list": ["USER_ID_1", "USER_ID_2"], "start_time": "YYYY-MM-DD HH:MM:SS", "end_time": "YYYY-MM-DD HH:MM:SS"}'
 ```
 
 ## 返回字段

--- a/skills/wecomcli-manage-smartsheet-schema/SKILL.md
+++ b/skills/wecomcli-manage-smartsheet-schema/SKILL.md
@@ -108,12 +108,11 @@ wecom-cli doc smartsheet_delete_fields '{"docid": "DOCID", "sheet_id": "SHEETID"
 
 1. **了解表结构** → 
 ```bash
-wecom-cli doc smartsheet_get_sheet
+wecom-cli doc smartsheet_get_sheet '{"docid": "DOCID"}'
 ```
  →
 ```bash
-wecom-cli doc smartsheet_get_fields
+wecom-cli doc smartsheet_get_fields '{"docid": "DOCID", "sheet_id": "SHEETID"}'
 ```
 2. **创建表结构** → `smartsheet_add_sheet` 添加子表 → `smartsheet_add_fields` 定义列
 3. **修改表结构** → `smartsheet_update_fields` 改列名 / `smartsheet_delete_fields` 删列
-


### PR DESCRIPTION
## 背景

当前仓库的项目说明和使用文档主要集中在根 `README.md`，导致首页介绍、命令参考、Skill 索引和工作流示例混在一起。随着内容增长，读者会比较难判断：

- 应该从哪里开始看
- 哪些页面是长期维护的主入口
- 哪些命令行为已经和当前实现产生漂移

## 这次发现的问题

- 根 `README.md` 既承担项目首页，又承担较长的 CLI 参考和业务示例，信息密度过高，缺少清晰的 source-of-truth 边界。
- 部分文档描述和当前 CLI 实现不一致：
  - `wecom-cli <category> --help` 实际依赖先完成 `init`，因为工具定义来自 MCP。
  - `wecom-cli <category> <method>` 在省略 `json_args` 时会展示 tool schema/help，而不是直接执行调用。
  - `init --refresh` 已在实现中存在，但原文档没有覆盖。
- 个别 Skill 文档存在示例漂移或不一致：
  - `check_availability` 的命令拼写不一致。
  - 智能表格 schema 管理示例里缺少必要的 JSON 参数，容易让读者误以为无参也会执行。

## 这次修改了什么

- 新增 `docs/` 文档目录，补充独立的文档入口页。
- 将根 `README.md` 收敛为项目首页，保留项目介绍、最短上手路径和文档导航。
- 新增以下专题文档：
  - `docs/getting-started.md`：安装、初始化、首个调用
  - `docs/cli-reference.md`：已验证的 CLI 行为、运行时路径、环境变量
  - `docs/skills.md`：12 个 Skills 的入口和分类导航
  - `docs/development.md`：源码结构、本地开发与打包边界
- 修正相关 Skill 文档中的命令拼写和示例参数，使之与当前 CLI 行为保持一致。

## 影响

- 新用户能更快找到正确入口，而不是直接在根 `README.md` 中翻找长篇内容。
- 维护者后续可以更清楚地区分：项目首页、长期维护文档、单个 Skill 细节说明分别放在哪里。
- 文档示例与当前实现更加对齐，降低“照着 README 执行却发现行为不一样”的困惑。

## 验证

- `cargo test`
- `cargo run -- --help`
- `cargo run -- init --help`
- `cargo run -- contact --help`
  - 在未初始化时按预期失败：`未找到企业微信机器人信息，请先运行 \`wecom-cli init\``
- 对 `README.md` 和 `docs/*.md` 做了相对链接检查

## 备注

这版优先解决文档结构和已确认的 CLI 行为漂移问题。

Issue #1 中提到的 “Bot ID / Secret 具体从哪里获取” 仍然是一个值得继续补充的 onboarding 问题；如果 maintainer 认为方向合适，这部分可以在后续继续补进 `getting-started`。

Refs #1
