### PR TITLE
feat: 支持环境变量初始化 + 新增卸载文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ wecom-cli init
 wecom-cli contact get_userlist '{}'
 ```
 
-📖 更多使用方法，请参阅 [CLI 命令参考](docs/cli-reference.md)。
+📖 更多使用方法，请参阅 [CLI 命令参考](docs/cli-reference.md)。如需卸载，请参阅 [卸载指南](docs/uninstall.md)。
 
 ## Agent Skills
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@
 - 查看 CLI 使用方法、运行时路径和环境变量：[`docs/cli-reference.md`](cli-reference.md)
 - 查看内置 Skills 的分工和入口：[`docs/skills.md`](skills.md)
 - 本地开发、调试和仓库结构：[`docs/development.md`](development.md)
+- 卸载 CLI 和清理配置：[`docs/uninstall.md`](uninstall.md)
 
 ## 维护约定
 

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -1,0 +1,31 @@
+# 卸载 wecom-cli
+
+## 步骤 1：移除 CLI
+
+```bash
+npm uninstall -g @wecom/cli
+```
+
+## 步骤 2：移除 CLI Skill
+
+```bash
+npx skills remove WeComTeam/wecom-cli -g
+```
+
+如果提示 `skills` 命令不存在，先安装：
+
+```bash
+npm install -g @anthropic-ai/skills
+```
+
+## 步骤 3：清理本地配置和数据
+
+```bash
+# 删除配置目录（包含 Bot 凭证、MCP 配置、缓存）
+rm -rf ~/.config/wecom/
+
+# 删除临时媒体文件
+rm -rf "${TMPDIR:-/tmp}/wecom/"
+```
+
+> 注意：WECOM_CLI_CONFIG_DIR 或 WECOM_CLI_TMP_DIR 环境变量会覆盖上述默认路径，请按照你实际配置的路径清理。

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -3,6 +3,7 @@ use std::io::IsTerminal;
 use crate::auth;
 use crate::mcp;
 use crate::mcp::config::McpBindSource;
+use crate::constants;
 use anyhow::Result;
 use clap::{ArgMatches, Args, Command, FromArgMatches};
 
@@ -32,15 +33,27 @@ pub async fn handle_init_cmd(matches: &ArgMatches) -> Result<()> {
     cliclack::intro("企业微信机器人初始化")?;
 
     let (bot, bind_source) = if args.noninteractive {
-        (init_qrcode().await?, McpBindSource::Qrcode)
+        init_noninteractive().await?
     } else {
-        let method: &str = cliclack::select("请选择企微机器人接入方式：")
-            .item("qrcode", "扫码接入（推荐）", "")
-            .item("manual", "手动输入 Bot ID 和 Secret", "")
-            .interact()?;
+        let env_available = std::env::var(constants::env::BOT_ID).is_ok()
+            && std::env::var(constants::env::BOT_SECRET).is_ok();
+
+        let method: &str = if env_available {
+            cliclack::select("请选择企微机器人接入方式：")
+                .item("qrcode", "扫码接入（推荐）", "")
+                .item("manual", "手动输入 Bot ID 和 Secret", "")
+                .item("env", "从环境变量读取（WECOM_BOT_ID / WECOM_SECRET）", "")
+                .interact()?
+        } else {
+            cliclack::select("请选择企微机器人接入方式：")
+                .item("qrcode", "扫码接入（推荐）", "")
+                .item("manual", "手动输入 Bot ID 和 Secret", "")
+                .interact()?
+        };
 
         match method {
             "qrcode" => (init_qrcode().await?, McpBindSource::Qrcode),
+            "env" => (init_env()?, McpBindSource::Env),
             _ => (init_manual().await?, McpBindSource::Interactive),
         }
     };
@@ -52,6 +65,27 @@ pub async fn handle_init_cmd(matches: &ArgMatches) -> Result<()> {
 /// 扫码接入流程
 async fn init_qrcode() -> Result<auth::Bot> {
     auth::scan_qrcode_for_bot().await
+}
+
+/// 环境变量接入流程
+fn init_env() -> Result<auth::Bot> {
+    let bot_id = std::env::var(constants::env::BOT_ID)
+        .map_err(|_| anyhow::anyhow!("环境变量 {} 未设置", constants::env::BOT_ID))?;
+    let bot_secret = std::env::var(constants::env::BOT_SECRET)
+        .map_err(|_| anyhow::anyhow!("环境变量 {} 未设置", constants::env::BOT_SECRET))?;
+    Ok(auth::Bot::new(bot_id, bot_secret))
+}
+
+/// 非交互式接入流程：优先从环境变量读取，否则走扫码
+async fn init_noninteractive() -> Result<(auth::Bot, McpBindSource)> {
+    if let (Ok(bot_id), Ok(bot_secret)) = (
+        std::env::var(constants::env::BOT_ID),
+        std::env::var(constants::env::BOT_SECRET),
+    ) {
+        cliclack::log::info("使用环境变量 WECOM_BOT_ID / WECOM_SECRET 初始化")?;
+        return Ok((auth::Bot::new(bot_id, bot_secret), McpBindSource::Env));
+    }
+    Ok((init_qrcode().await?, McpBindSource::Qrcode))
 }
 
 /// 手动输入 Bot ID 和 Secret

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -17,6 +17,12 @@ pub mod env {
     /// MCP config URL (仅在启用 `custom-endpoint` feature 后使用)
     #[cfg_attr(not(feature = "custom-endpoint"), allow(dead_code))]
     pub const MCP_CONFIG_ENDPOINT: &str = "WECOM_CLI_MCP_CONFIG_ENDPOINT";
+
+    /// Bot ID for non-interactive init (set via env var for CI/CD automation)
+    pub const BOT_ID: &str = "WECOM_BOT_ID";
+
+    /// Bot Secret for non-interactive init (set via env var for CI/CD automation)
+    pub const BOT_SECRET: &str = "WECOM_SECRET";
 }
 
 /// Return the MCP config endpoint URL (env override or the default WeCom API).

--- a/src/mcp/config.rs
+++ b/src/mcp/config.rs
@@ -22,6 +22,8 @@ pub enum McpBindSource {
     Interactive = 1,
     /// QR Code
     Qrcode = 2,
+    /// Environment variable (WECOM_BOT_ID + WECOM_SECRET)
+    Env = 3,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -367,6 +369,8 @@ mod tests {
         assert_eq!(json, "1", "Expected number 1, got: {json}");
         let json = serde_json::to_string(&McpBindSource::Qrcode).unwrap();
         assert_eq!(json, "2", "Expected number 2, got: {json}");
+        let json = serde_json::to_string(&McpBindSource::Env).unwrap();
+        assert_eq!(json, "3", "Expected number 3, got: {json}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

两个小改进：

### 1. 支持通过环境变量初始化 (fixes #45)

当前 `wecom-cli init` 必须交互式输入（扫码或手动填 Bot ID/Secret），无法在 CI/CD 等自动化场景使用。

改动：
- 新增 `WECOM_BOT_ID` 和 `WECOM_SECRET` 环境变量
- **非交互模式**（`--noninteractive`）：优先从环境变量读取，未设置时回退到扫码
- **交互模式**：当环境变量已设置时，选择菜单会多出"从环境变量读取"选项
- 新增 `McpBindSource::Env` 枚举值用于追踪凭证来源

使用方式：
```bash
export WECOM_BOT_ID=your_bot_id
export WECOM_SECRET=your_secret
wecom-cli init --noninteractive
```

### 2. 新增卸载文档 (fixes #41)

- 新增 `docs/uninstall.md`，覆盖 CLI 卸载、Skill 移除、本地配置清理三个步骤
- 在 `docs/README.md` 和主 `README.md` 中添加链接

### 改动文件

| 文件 | 改动 |
|------|------|
| `src/constants.rs` | +6 行，新增 `BOT_ID` / `BOT_SECRET` 环境变量常量 |
| `src/cmd/init.rs` | 重构 init 流程，新增 `init_env()` 和 `init_noninteractive()` |
| `src/mcp/config.rs` | +2 行，新增 `McpBindSource::Env` 枚举值 + 测试 |
| `docs/uninstall.md` | 新增卸载指南 |
| `docs/README.md` | +1 行，文档索引 |
| `README.md` | +1 行，卸载链接 |

## Test plan

- [ ] `wecom-cli init --noninteractive` 读取 `WECOM_BOT_ID` / `WECOM_SECRET` 环境变量
- [ ] 未设置环境变量时 `--noninteractive` 回退到扫码
- [ ] 交互模式下环境变量存在时出现第三选项
- [ ] McpBindSource::Env 序列化为 `3`