### PR TITLE
fix: correct keyring fallback logic in try_decrypt_data

### DIFF
--- a/src/crypto/keystore.rs
+++ b/src/crypto/keystore.rs
@@ -107,19 +107,25 @@ pub fn decrypt_data<T: serde::de::DeserializeOwned>(data: &[u8], key: &[u8; 32])
     serde_json::from_slice(&decrypted).map_err(|e| anyhow::anyhow!("JSON deserialize error: {e:#}"))
 }
 
-/// Try to decrypt data using the cached/keyring key first; on failure, fall back to the file key.
+/// Try to decrypt data using the file key first; on failure, fall back to the keyring key.
 pub fn try_decrypt_data<T: serde::de::DeserializeOwned>(data: &[u8]) -> Result<T> {
-    // 1. Try cached key (covers both keyring and file sources)
+    // 1. Try file key first
     if let Some(key) = load_key_from_file() {
         if let Ok(result) = decrypt_data::<T>(data, &key) {
             return Ok(result);
         }
-        tracing::debug!("Cached key failed to decrypt, trying file key directly…");
+        tracing::debug!("File key failed to decrypt, trying keyring key…");
     }
 
-    // 2. Fall back to file key (in case cache holds a stale keyring key)
-    let key = load_key_from_file().ok_or(anyhow::anyhow!("解密数据失败（未找到有效密钥）",))?;
-    decrypt_data(data, &key)
+    // 2. Fall back to keyring key (in case file key is stale or unavailable)
+    if let Some(key) = load_key_from_keyring() {
+        if let Ok(result) = decrypt_data::<T>(data, &key) {
+            return Ok(result);
+        }
+        tracing::debug!("Keyring key also failed to decrypt");
+    }
+
+    Err(anyhow::anyhow!("解密数据失败（未找到有效密钥）"))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 改动

**修复 try_decrypt_data 函数的密钥回退逻辑错误**

在 `src/crypto/keystore.rs` 中，`try_decrypt_data` 函数存在致命 bug：第1步和第2步都调用 `load_key_from_file()`，导致完全相同的密钥被尝试两次，而 keyring 中的密钥从未被尝试。当使用系统 keyring 存储加密密钥时，加密的数据将无法被解密。

### 问题分析

**修复前：**
```rust
pub fn try_decrypt_data<T: serde::de::DeserializeOwned>(data: &[u8]) -> Result<T> {
    // 1. Try cached key (covers both keyring and file sources)
    if let Some(key) = load_key_from_file() {
        if let Ok(result) = decrypt_data::<T>(data, &key) {
            return Ok(result);
        }
        tracing::debug!("Cached key failed to decrypt, trying file key directly…");
    }

    // 2. Fall back to file key (in case cache holds a stale keyring key)
    let key = load_key_from_file().ok_or(...)?;
    decrypt_data(data, &key)
}
```

**问题：**
- 第1步和第2步都使用 `load_key_from_file()`
- 日志信息 "trying file key directly" 是误导性的
- keyring 中的密钥从未被尝试

**修复后：**
```rust
pub fn try_decrypt_data<T: serde::de::DeserializeOwned>(data: &[u8]) -> Result<T> {
    // 1. Try file key first
    if let Some(key) = load_key_from_file() {
        if let Ok(result) = decrypt_data::<T>(data, &key) {
            return Ok(result);
        }
        tracing::debug!("File key failed to decrypt, trying keyring key…");
    }

    // 2. Fall back to keyring key (in case file key is stale or unavailable)
    if let Some(key) = load_key_from_keyring() {
        if let Ok(result) = decrypt_data::<T>(data, &key) {
            return Ok(result);
        }
        tracing::debug!("Keyring key also failed to decrypt");
    }

    Err(anyhow::anyhow!("解密数据失败（未找到有效密钥）"))
}
```

### 影响范围

此 bug 影响以下加密数据的解密：
- `bot.enc` - 企业微信机器人凭证
- `mcp_config.enc` - MCP 配置缓存

关联 Issue: #

## 检查项

- [x] 代码已自测通过
- [x] 无调试代码残留
- [x] 文档已同步更新（如有需要）
