### PR TITLE
feat: 默认启用自定义 MCP 配置地址

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["command-line-utilities"]
 include = ["/src/**/*", "/build.rs", "/Cargo.toml", "/Cargo.lock", "/LICENSE", "/README.md"]
 
 [features]
+default = ["custom-endpoint"]
 custom-endpoint = []
 
 [[bin]]

--- a/docs/development.md
+++ b/docs/development.md
@@ -22,3 +22,14 @@
 - 根包名为 `@wecom/cli`，实际可执行入口是 `bin/wecom.js`。
 - 平台二进制通过 `optionalDependencies` 分发，位于 `packages/*`。
 - `pnpm-workspace.yaml` 当前只管理 `packages/*` 工作区。
+
+## 自定义 MCP 配置地址
+
+默认构建启用 `custom-endpoint` feature，可通过环境变量覆盖 `init` 获取 MCP 配置的地址：
+
+```bash
+WECOM_CLI_MCP_CONFIG_ENDPOINT=http://127.0.0.1:8080/mcp-config wecom-cli init
+```
+
+环境变量未设置或值为空时使用企业微信官方地址。需要禁用该能力时，可以使用
+`cargo build --no-default-features` 构建。

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -22,10 +22,17 @@ pub mod env {
 /// Return the MCP config endpoint URL (env override or the default WeCom API).
 pub fn mcp_config_endpoint() -> String {
     #[cfg(feature = "custom-endpoint")]
-    if let Ok(url) = std::env::var(env::MCP_CONFIG_ENDPOINT) {
+    if let Some(url) = normalize_custom_endpoint(std::env::var(env::MCP_CONFIG_ENDPOINT).ok()) {
         return url;
     }
     DEFAULT_MCP_CONFIG_ENDPOINT.to_string()
+}
+
+#[cfg(feature = "custom-endpoint")]
+fn normalize_custom_endpoint(value: Option<String>) -> Option<String> {
+    value
+        .map(|url| url.trim().to_string())
+        .filter(|url| !url.is_empty())
 }
 
 pub fn get_user_agent() -> String {


### PR DESCRIPTION
默认启用 `custom-endpoint` feature，允许通过 `WECOM_CLI_MCP_CONFIG_ENDPOINT` 统一配置 MCP config endpoint。

该能力用于企业环境统一配置出口和凭据管理。环境变量未设置或为空时仍使用官方地址，也可通过 `--no-default-features` 关闭。